### PR TITLE
Added functionality to load MarsBench data from HuggingFace

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,85 +1,611 @@
 # MarsBench Usage Examples
 
-This document provides ready-to-use examples for running MarsBench commands in various scenarios.
+Focused, comprehensive examples for running MarsBench with Hugging Face–hosted datasets and (optionally) locally downloaded data (from Zenodo).
 
-## Basic Commands
+Sections:
+1. Base Example
+2. Command Builder
+3. Classification Tutorial
+4. Segmentation Tutorial
+5. Detection Tutorial
+6. Callbacks (and Logging / Monitoring)
+7. Advanced Patterns
+8. Batch Runs
 
-### Training a Model
+---
+
+### Reference Table: Datasets (internal name vs Hugging Face repo slug) and Available Models
+
+NOTE:
+- data_name is the value you pass via data_name=...
+- HF Repo Slug column shows the suffix part used in repo_id="ORG/<slug>" (Organization/user prefix e.g. Mirali33 may differ)
+- Model Name column lists all registered models for that task 
+- If any slug differs in your local version, open marsbench/data/__init__.py for the authoritative mapping
+
+| Task Type | Dataset Name (data_name param) | HF Repo Slug (example) | Model Names (model_name) |
+|-----------|--------------------------------|------------------------|---------------------------|
+| classification | domars16k | mb-domars16k | resnet101, vit, swin_transformer, inceptionv3, squeezenet |
+| classification | atmospheric_dust_classification_edr | mb-atmospheric_dust_cls_edr | resnet101, vit, swin_transformer, inceptionv3, squeezenet |
+| classification | atmospheric_dust_classification_rdr | mb-atmospheric_dust_cls_rdr | resnet101, vit, swin_transformer, inceptionv3, squeezenet |
+| classification | change_classification_ctx | mb-change_cls_ctx | resnet101, vit, swin_transformer, inceptionv3, squeezenet |
+| classification | change_classification_hirise | mb-change_cls_hirise | resnet101, vit, swin_transformer, inceptionv3, squeezenet |
+| classification | frost_classification | mb-frost_cls | resnet101, vit, swin_transformer, inceptionv3, squeezenet |
+| classification | landmark_classification | mb-landmark_cls | resnet101, vit, swin_transformer, inceptionv3, squeezenet |
+| classification | surface_classification | mb-surface_cls | resnet101, vit, swin_transformer, inceptionv3, squeezenet |
+| classification | multi_label_mer | mb-surface_multi_label_cls | resnet101, vit, swin_transformer, inceptionv3, squeezenet |
+| segmentation | boulder_segmentation | mb-boulder_seg | unet, deeplab, dpt, mask_rcnn, mask2former, segformer |
+| segmentation | conequest_segmentation | mb-conequest_seg | unet, deeplab, dpt, mask_rcnn, mask2former, segformer |
+| segmentation | crater_binary_segmentation | mb-crater_binary_seg | unet, deeplab, dpt, mask_rcnn, mask2former, segformer |
+| segmentation | crater_multi_segmentation | mb-crater_multi_seg | unet, deeplab, dpt, mask_rcnn, mask2former, segformer |
+| segmentation | mmls | mb-mmls | unet, deeplab, dpt, mask_rcnn, mask2former, segformer |
+| segmentation | mars_seg_mer | mb-mars_seg_mer | unet, deeplab, dpt, mask_rcnn, mask2former, segformer |
+| segmentation | mars_seg_msl | mb-mars_seg_msl | unet, deeplab, dpt, mask_rcnn, mask2former, segformer |
+| segmentation | s5mars | mb-s5mars | unet, deeplab, dpt, mask_rcnn, mask2former, segformer |
+| detection | boulder_detection | mb-boulder_det | fasterrcnn, retinanet, ssd |
+| detection | conequest_detection | mb-conequest_det* | fasterrcnn, retinanet, ssd |
+| detection | dust_devil_detection | mb-dust_devil_det | fasterrcnn, retinanet, ssd |
+
+---
+
+## 1. Base Example
+
+A minimal training run on a Hugging Face dataset:
 
 ```bash
-# Basic classification training
-python -m marsbench.main task=classification model_name=resnet18 data_name=domars16k
-
-# Segmentation training with specific data path
-python -m marsbench.main task=segmentation model_name=unet data_name=cone_quest dataset_path=/path/to/data
-
-# Training with test after training
-python -m marsbench.main task=classification model_name=resnet50 data_name=msl_net test_after_training=true
+python -m marsbench.main \
+  mode=train \
+  task=classification \
+  model_name=resnet101 \
+  data_name=domars16k \
+  load_from_hf=true \
+  repo_id="Mirali33/mb-domars16k" \
+  training.trainer.max_epochs=1
 ```
 
-### Testing a Trained Model
+Key points:
+- mode=train (default if omitted)
+- load_from_hf=true + repo_id="..." tells MarsBench to fetch the dataset via Hugging Face Hub.
+- training.trainer.max_epochs=1 keeps it fast for a smoke test.
+
+(If the dataset is already cached by datasets library, it will reuse it.)
+
+---
+
+## 2. Command Builder
+
+MarsBench uses Hydra. Every CLI override is key=value. Nested config segments (e.g., training.trainer.max_epochs) descend into YAML structure.
+
+General template:
 
 ```bash
-# Test a model
-python -m marsbench.main mode=test task=classification model_name=resnet18 data_name=domars16k
-
-# Test a trained model using its checkpoint
-python -m marsbench.main mode=test task=classification model_name=resnet18 data_name=domars16k checkpoint_path=outputs/classification/domars16k/resnet18/YYYY-MM-DD_HH-MM-SS/checkpoints/best.ckpt
-
-# Test a model and save benchmark results with custom output path
-python -m marsbench.main mode=test task=classification model_name=resnet18 data_name=domars16k checkpoint_path=outputs/classification/domars16k/resnet18/YYYY-MM-DD_HH-MM-SS/checkpoints/best.ckpt output_path=results/my_benchmark
+python -m marsbench.main \
+  mode=<train|test|predict> \
+  task=<classification|segmentation|detection> \
+  model_name=<registered_model_key> \
+  data_name=<registered_dataset_key> \
+  [load_from_hf=true repo_id="HF_ORG/REPO"] \
+  [dataset_path=/absolute/or/relative/path] \
+  [checkpoint_path=path/to/checkpoint.ckpt] \
+  [output_path=custom/output/dir] \
+  [prediction_output_path=preds/out] \
+  training.trainer.max_epochs=E \
+  training.batch_size=B \
+  training.optimizer.lr=LR \
+  transforms=<transforms_config_name> \
+  callbacks.early_stopping.patience=10 \
+  logger.wandb.enabled=true
 ```
 
-### Generating Predictions
+Parameter sources:
+- model_name: must exist in configs/model/<task>/
+- data_name: must exist in configs/data/<task>/
+- transforms: defined in configs/transforms/
+- logger.*, callbacks.*, training.* are in respective config trees.
+- Use +key=value to introduce keys not predefined (Hydra strict mode safeguard).
+
+Quoting:
+- Quote strings containing special characters or uppercase letters when in doubt: repo_id="Mirali33/mb-boulder_det"
+
+Hydra multirun (launch several sweeps):
+```bash
+python -m marsbench.main -m \
+  task=classification model_name=resnet101 data_name=domars16k load_from_hf=true repo_id="Mirali33/mb-domars16k" \
+  training.optimizer.lr=0.001,0.0005 training.batch_size=32,64
+```
+Outputs go into multirun/ timestamped folders.
+
+---
+
+## 3. Classification Tutorial
+
+Step-by-step from zero to evaluation.
+
+### 3.1 Choose a Dataset (Hugging Face)
+
+Check mapping in marsbench/data/__init__.py (datasets like domars16k, atmospheric_dust_classification_edr, surface_classification, etc.). Example using atmospheric dust:
 
 ```bash
-# Inference
-python -m marsbench.main mode=predict task=classification model_name=resnet18 data_name=domars16k
-
-# Generate predictions with a trained model
-python -m marsbench.main mode=predict task=classification model_name=resnet18 data_name=domars16k checkpoint_path=outputs/classification/domars16k/resnet18/YYYY-MM-DD_HH-MM-SS/checkpoints/best.ckpt
-
-# Predictions with custom output path
-python -m marsbench.main mode=predict task=classification model_name=resnet18 data_name=hirise_net checkpoint_path=outputs/classification/hirise_net/resnet18/latest/checkpoints/best.ckpt prediction_output_path=predictions/hirise_results
+python -m marsbench.main \
+  mode=train \
+  task=classification \
+  model_name=resnet101 \
+  data_name=atmospheric_dust_classification_edr \
+  load_from_hf=true \
+  repo_id="Mirali33/mb-atmospheric_dust_cls_edr" \
+  training.trainer.max_epochs=3 \
+  training.batch_size=32
 ```
 
-## Advanced Usage
+### 3.2 Using Local Data (Zenodo Download)
 
-### Customizing Training Parameters
-
+1. Download the archive (e.g., domars16k.zip) from Zenodo
+2. Unzip: `unzip domars16k.zip -d /data/mars/`
+3. Ensure folder structure matches the expected pipeline
+4. Run without load_from_hf:
 ```bash
-# Change learning rate and batch size
-python -m marsbench.main task=classification model_name=resnet18 data_name=domars16k training.optimizer.lr=0.001 training.batch_size=64
-
-# Use a different optimizer
-python -m marsbench.main task=classification model_name=resnet18 data_name=domars16k training.optimizer.name=AdamW
-
-# Set the number of epochs
-python -m marsbench.main task=classification model_name=resnet18 data_name=domars16k training.max_epochs=50
+python -m marsbench.main \
+  task=classification \
+  model_name=resnet101 \
+  data_name=domars16k \
+  dataset_path=/data/mars/domars16k \
+  training.trainer.max_epochs=2
 ```
 
-### Data and Transforms
+NOTE: Do not keep .zip files compressed; the dataloader expects extracted directories.
+
+### 3.3 Adjust Training Hyperparameters
 
 ```bash
-# Apply custom data transformations
-python -m marsbench.main task=classification model_name=resnet18 data_name=domars16k transforms=default
-
-# Specify a different validation split
-python -m marsbench.main task=classification model_name=resnet18 data_name=domars16k training.trainer.limit_val_batches=0.2
-
-# Use a subset of data for quick experiments (add + before the key for default undefineds)
-python -m marsbench.main task=classification model_name=resnet18 data_name=domars16k +data.subset=1000
+python -m marsbench.main \
+  task=classification model_name=resnet101 data_name=domars16k \
+  load_from_hf=true repo_id="Mirali33/mb-domars16k" \
+  training.optimizer.name=AdamW \
+  training.optimizer.lr=0.0007 \
+  training.scheduler.name=cosine \
+  training.trainer.max_epochs=10 \
+  training.trainer.accumulate_grad_batches=2 \
+  training.trainer.precision=16
 ```
 
-### Logging and Callbacks
+### 3.4 Validation Limits / Quick Debug
 
 ```bash
-# Enable WandB logging
-python -m marsbench.main task=classification model_name=resnet18 data_name=domars16k logger.wandb.enabled=true
+python -m marsbench.main \
+  task=classification model_name=resnet101 data_name=domars16k \
+  load_from_hf=true repo_id="Mirali33/mb-domars16k" \
+  training.trainer.fast_dev_run=1
+```
 
-# Set early stopping parameters (alternately set early stop patience training.early_stopping_patience)
-python -m marsbench.main task=classification model_name=resnet18 data_name=domars16k callbacks.early_stopping.patience=10 callbacks.early_stopping.monitor=val/accuracy callbacks.early_stopping.mode=max
+OR subset:
+```bash
+python -m marsbench.main \
+  task=classification model_name=resnet101 data_name=domars16k \
+  load_from_hf=true repo_id="Mirali33/mb-domars16k" \
+  +data.subset=1000
+```
 
-# Save multiple checkpoints
-python -m marsbench.main task=classification model_name=resnet18 data_name=domars16k callbacks.best_checkpoint.save_top_k=3
+### 3.5 Testing After Training
+
+Either add:
+```bash
+... test_after_training=true
+```
+Or run separately:
+```bash
+python -m marsbench.main \
+  mode=test \
+  task=classification \
+  model_name=resnet101 \
+  data_name=domars16k \
+  checkpoint_path=outputs/classification/domars16k/resnet101/<RUN_ID>/checkpoints/best.ckpt
+```
+
+### 3.6 Generating Predictions
+
+```bash
+python -m marsbench.main \
+  mode=predict \
+  task=classification \
+  model_name=resnet101 \
+  data_name=domars16k \
+  checkpoint_path=outputs/classification/domars16k/resnet101/<RUN_ID>/checkpoints/best.ckpt \
+  prediction_output_path=predictions/domars16k_resnet101
+```
+
+### 3.7 Multi-GPU (if available)
+
+```bash
+python -m marsbench.main \
+  task=classification model_name=resnet101 data_name=domars16k \
+  load_from_hf=true repo_id="Mirali33/mb-domars16k" \
+  training.trainer.accelerator=gpu \
+  training.trainer.devices=2 \
+  training.trainer.strategy=ddp
+```
+
+---
+
+## 4. Segmentation
+
+Example dataset names: boulder_segmentation, conequest_segmentation, crater_binary_segmentation, crater_multi_segmentation, mars_seg_mer, mars_seg_msl, s5mars, mmls 
+
+### 4.1 Basic U-Net on ConeQuest (Hugging Face)
+
+```bash
+python -m marsbench.main \
+  task=segmentation \
+  model_name=unet \
+  data_name=conequest_segmentation \
+  load_from_hf=true \
+  repo_id="Mirali33/mb-conequest_seg" \
+  training.trainer.max_epochs=5
+```
+
+### 4.2 Partial Dataset Partition (Fast Experiment)
+
+If config exposes partition (e.g., partition=0.1 used earlier):
+
+```bash
+python -m marsbench.main \
+  task=segmentation model_name=unet data_name=boulder_segmentation \
+  load_from_hf=true repo_id="Mirali33/mb-boulder_seg" \
+  partition=0.1 \
+  training.trainer.max_epochs=2
+```
+
+### 4.3 Changing Transforms
+
+Check configs/transforms/ for segmentation-specific transforms (e.g., seg_default, heavy_aug). Example:
+
+```bash
+python -m marsbench.main \
+  task=segmentation model_name=unet data_name=cone_quest_segmentation \
+  load_from_hf=true repo_id="Mirali33/mb-conequest_seg" \
+  transforms=seg_default \
+  training.trainer.max_epochs=10
+```
+
+### 4.4 Switch Model (DeepLab)
+
+```bash
+python -m marsbench.main \
+  task=segmentation \
+  model_name=deeplab \
+  data_name=cone_quest_segmentation \
+  load_from_hf=true repo_id="Mirali33/mb-conequest_seg" \
+  training.optimizer.lr=0.0001 \
+  training.trainer.max_epochs=15
+```
+
+### 4.5 Mixed Precision + Gradient Accumulation
+
+```bash
+python -m marsbench.main \
+  task=segmentation model_name=unet data_name=boulder_segmentation \
+  load_from_hf=true repo_id="Mirali33/mb-boulder_seg" \
+  training.trainer.precision=16 \
+  training.trainer.accumulate_grad_batches=4 \
+  training.trainer.max_epochs=20
+```
+
+---
+
+## 5. Detection
+
+Dataset keys may include boulder_detection, conequest_detection, dust_devil_detection.
+
+### 5.1 SSD on Boulder Detection (Hugging Face)
+
+```bash
+python -m marsbench.main \
+  task=detection \
+  model_name=ssd \
+  data_name=boulder_detection \
+  load_from_hf=true \
+  repo_id="Mirali33/mb-boulder_det" \
+  training.trainer.max_epochs=5
+```
+
+### 5.2 Faster R-CNN with Learning Rate Override
+
+```bash
+python -m marsbench.main \
+  task=detection \
+  model_name=faster_rcnn \
+  data_name=boulder_detection \
+  load_from_hf=true repo_id="Mirali33/mb-boulder_det" \
+  training.optimizer.lr=0.0002 \
+  training.trainer.max_epochs=12
+```
+
+### 5.3 Evaluation Only
+
+```bash
+python -m marsbench.main \
+  mode=test \
+  task=detection \
+  model_name=ssd \
+  data_name=boulder_detection \
+  checkpoint_path=outputs/detection/boulder_detection/ssd/<RUN_ID>/checkpoints/best.ckpt
+```
+
+---
+
+## 6. Callbacks (and Logging)
+
+MarsBench integrates PyTorch Lightning callbacks & loggers via configs/callbacks and configs/logger.
+
+Common callbacks keys (exact keys depend on YAML):
+- callbacks.early_stopping.*
+- callbacks.best_checkpoint.* (model checkpoint)
+- callbacks.lr_monitor.enabled
+- callbacks.progress_bar.refresh_rate
+
+### 6.1 Early Stopping
+
+```bash
+python -m marsbench.main \
+  task=classification model_name=resnet101 data_name=domars16k \
+  load_from_hf=true repo_id="Mirali33/mb-domars16k" \
+  callbacks.early_stopping.monitor=val/accuracy \
+  callbacks.early_stopping.mode=max \
+  callbacks.early_stopping.patience=8
+```
+
+### 6.2 Multiple Best Checkpoints
+
+```bash
+python -m marsbench.main \
+  task=classification model_name=resnet101 data_name=domars16k \
+  load_from_hf=true repo_id="Mirali33/mb-domars16k" \
+  callbacks.best_checkpoint.save_top_k=3 \
+  callbacks.best_checkpoint.monitor=val/accuracy \
+  callbacks.best_checkpoint.mode=max
+```
+
+### 6.3 Learning Rate Monitor
+
+```bash
+python -m marsbench.main \
+  task=segmentation model_name=unet data_name=cone_quest_segmentation \
+  load_from_hf=true repo_id="Mirali33/mb-conequest_seg" \
+  callbacks.lr_monitor.enabled=true
+```
+
+### 6.4 WandB Logging
+
+```bash
+python -m marsbench.main \
+  task=classification model_name=resnet101 data_name=domars16k \
+  load_from_hf=true repo_id="Mirali33/mb-domars16k" \
+  logger.wandb.enabled=true \
+  logger.wandb.project=MarsBench \
+  logger.wandb.name=domars16k_resnet101_test
+```
+
+### 6.5 TensorBoard + CSV
+
+```bash
+python -m marsbench.main \
+  task=classification model_name=resnet101 data_name=domars16k \
+  load_from_hf=true repo_id="Mirali33/mb-domars16k" \
+  logger.tensorboard.enabled=true \
+  logger.csv.enabled=true
+```
+
+### 6.6 Custom Output Path
+
+```bash
+python -m marsbench.main \
+  task=classification model_name=resnet101 data_name=domars16k \
+  load_from_hf=true repo_id="Mirali33/mb-domars16k" \
+  output_path=experiments/domars16k_resnet101_custom
+```
+
+---
+
+## 7. Advanced Patterns
+
+### 7.1 Hydra Sweep (Models x LRs)
+
+```bash
+python -m marsbench.main -m \
+  task=classification data_name=domars16k load_from_hf=true repo_id="Mirali33/mb-domars16k" \
+  model_name=resnet101,vit \
+  training.optimizer.lr=0.001,0.0005
+```
+
+### 7.2 Reproducibility
+
+```bash
+python -m marsbench.main \
+  task=classification model_name=resnet101 data_name=domars16k \
+  load_from_hf=true repo_id="Mirali33/mb-domars16k" \
+  seed=42
+```
+
+---
+
+## Local vs Hugging Face Summary
+
+| Scenario | Required Args |
+|----------|---------------|
+| Hugging Face dataset | load_from_hf=true repo_id="ORG/REPO" |
+| Local extracted folder | dataset_path=/path/to/folder (omit load_from_hf) |
+| Zenodo zip just downloaded | MUST unzip first; then dataset_path=<unzipped_root> |
+
+If both load_from_hf and dataset_path are given, precedence depends on dataset_path
+
+---
+
+## Troubleshooting Notes
+
+- ModuleNotFound: run `pip install -e .` from repo root.
+- CUDA OOM: reduce training.batch_size or use training.trainer.precision=16.
+- Slow startup: first HF dataset download; subsequent runs cached.
+- Permission issues on output: ensure outputs/ is writable or set output_path.
+
+---
+
+## 8. Batch Runs (SLURM Array on HPC)
+
+Purpose:
+Run many independent MarsBench configurations in parallel on an HPC using a SLURM job array. Each array index runs exactly one configuration (no Hydra -m multirun inside). This keeps logging isolated and makes failed reruns trivial.
+
+Key ideas:
+- Encode the Cartesian product of parameter lists into a COMBOS array.
+- Use SLURM_ARRAY_TASK_ID to select one combo.
+- Write one log (stdout+stderr) per array element via #SBATCH --output / --error.
+- Trap errors to record failing indices.
+
+### 8.1 Basic Classification Sweep Script
+
+Save as scripts/sweep_classification.sbatch (make executable: chmod +x scripts/sweep_classification.sbatch).
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=marsbench_hf
+#SBATCH --array=0-10             # TEMP placeholder; will be reset after combo count is known
+#SBATCH --time=00:10:00
+#SBATCH --cpus-per-task=4
+#SBATCH --gres=gpu:1
+#SBATCH -p general
+#SBATCH -q public
+#SBATCH -A grp_hkerner
+#SBATCH --mem=16G
+#SBATCH --output=./outputs/hpc/slurm-%A_%a.out
+#SBATCH --error=./outputs/hpc/slurm-%A_%a.out
+
+set -euo pipefail
+
+# --- User environment (EDIT) ---
+module load mamba
+source activate kerner_lab
+
+mkdir -p outputs/hpc
+
+# Parameter lists (EDIT freely)
+DATASETS=(domars16k atmospheric_dust_classification_edr atmospheric_dust_classification_rdr change_classification_ctx change_classification_hirise frost_classification landmark_classification surface_classification)
+MODELS=(resnet101 vit swin_transformer inceptionv3 squeezenet)
+HF_FLAG_VAL=(True False)
+BATCH_SIZES=(32)
+SEEDS=(42)
+
+# Build combos (Cartesian product)
+COMBOS=()
+for d in "${DATASETS[@]}"; do
+  for m in "${MODELS[@]}"; do
+    for hf in "${HF_FLAG_VAL[@]}"; do
+      for bs in "${BATCH_SIZES[@]}"; do
+        for seed in "${SEEDS[@]}"; do
+          COMBOS+=("${m},${d},${hf},${bs},${seed}")
+        done
+      done
+    done
+  done
+done
+
+TOTAL=${#COMBOS[@]}
+
+# Optional: Add print-total helper
+if [[ "${1:-}" == "--print-total" ]]; then
+  echo "Total combinations: ${#COMBOS[@]}"
+  exit 0
+fi
+
+# Extract combo
+IFS=',' read MODEL DATASET HF_FLAG BS SEED <<< "${COMBOS[$SLURM_ARRAY_TASK_ID]}"
+
+RUN_TAG="cls_${DATASET}_${MODEL}_bs${BS}_seed${SEED}_hf${HF_FLAG}"
+FAILED_LOG="outputs/hpc/failed_runs.txt"
+
+# On failure, append a single line with index and params
+trap 'echo "idx=${SLURM_ARRAY_TASK_ID} model=${MODEL} dataset=${DATASET} bs=${BS} seed=${SEED} hf=${HF_FLAG} " >> "${FAILED_LOG}"' ERR
+
+echo "=== Starting ${RUN_TAG} (array index ${SLURM_ARRAY_TASK_ID}/${TOTAL}) ==="
+
+python -m marsbench.main \
+  task=classification \
+  model_name="${MODEL}" \
+  data_name="${DATASET}" \
+  load_from_hf=${HF_FLAG} \
+  training.batch_size="${BS}" \
+  seed="${SEED}" \
+  training.trainer.max_epochs=1 \
+  logger.csv.enabled=true \
+  logger.tensorboard.enabled=false
+
+echo "=== Finished ${RUN_TAG} ==="
+
+```
+(Or temporarily add: echo "TOTAL=$TOTAL"; exit 0 just after computing TOTAL.) Then set --array=0-(TOTAL-1).
+
+
+### 8.2 Rerunning Failed Indices
+
+After job finishes:
+```bash
+sort -u status/failed_indices.txt > status/failed_indices.unique.txt
+FAILED=$(paste -sd, status/failed_indices.unique.txt)
+if [[ -n "$FAILED" ]]; then
+  sbatch --array=${FAILED} scripts/sweep_classification.sbatch
+fi
+```
+
+### 8.3 Segmentation Sweep Variant (Example Changes Only)
+
+Key differences:
+- task=segmentation
+- data_name=cone_quest_segmentation
+- models subset (unet deeplab)
+- maybe partition=0.2 for quick tuning
+
+Command section replacement:
+```bash
+python -m marsbench.main \
+  task=segmentation \
+  model_name="${MODEL}" \
+  data_name=cone_quest_segmentation \
+  load_from_hf=true \
+  repo_id="Mirali33/mb-conequest_seg" \
+  partition=0.2 \
+  training.optimizer.lr="${LR}" \
+  training.batch_size="${BS}" \
+  seed="${SEED}" \
+  training.trainer.max_epochs=20 \
+  output_path="${OUT_DIR}" \
+  callbacks.best_checkpoint.save_top_k=1
+```
+
+---
+## Minimal Cheatsheet
+
+Classification (HF):
+```bash
+python -m marsbench.main task=classification model_name=resnet101 data_name=domars16k load_from_hf=true repo_id="Mirali33/mb-domars16k"
+```
+
+Segmentation (HF):
+```bash
+python -m marsbench.main task=segmentation model_name=unet data_name=conequest_segmentation load_from_hf=true repo_id="Mirali33/mb-conequest_seg"
+```
+
+Detection (HF):
+```bash
+python -m marsbench.main task=detection model_name=ssd data_name=boulder_detection load_from_hf=true repo_id="Mirali33/mb-boulder_det"
+```
+
+Local (after unzip):
+```bash
+python -m marsbench.main task=classification model_name=resnet101 data_name=domars16k dataset_path=/data/mars/domars16k
+```
+
+Add early stopping:
+```bash
+... callbacks.early_stopping.patience=5 callbacks.early_stopping.monitor=val/accuracy callbacks.early_stopping.mode=max
+```
+
+Enable WandB:
+```bash
+... logger.wandb.enabled=true logger.wandb.project=MarsBench
 ```

--- a/marsbench/configs/config.yaml
+++ b/marsbench/configs/config.yaml
@@ -11,6 +11,8 @@ dataset_path: /data/hkerner/MarsBench/NewDatasets  # Base path to datasets
 few_shot: null               # Support [null, 1, 2, 5, 10, 15, 20]
 partition: null              # Supported: [null, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1]
 test_after_training: true    # Run test after training completes
+load_from_hf: False          # Whether to load model from Hugging Face Hub (if true, repo_id must be specified)
+repo_id: ""                  # Hugging Face repository ID when load_from_hf=True
 
 # Model settings
 model_name: resnet101        # Name of the model architecture
@@ -21,7 +23,7 @@ checkpoint_path: null        # Path to a .ckpt file to resume training
 detection_confidence_threshold: 0.3
 
 # Output settings
-output_path: /scratch/vmaliviy/Marsbench/outputs         # Directory for outputs (models, logs, metrics)
+output_path: /scratch/ihmehta/Marsbench/outputs         # Directory for outputs (models, logs, metrics)
 prediction_output_path: null # Directory for prediction outputs; defaults to output_path/predictions
 
 defaults:

--- a/marsbench/data/__init__.py
+++ b/marsbench/data/__init__.py
@@ -246,9 +246,6 @@ def get_dataset(
             logger.warning(f"Using default repository ID: {cfg.repo_id}")
         
         if not is_hf_logged_in():
-            print("Hugging Face user not logged in. Please run `huggingface-cli login` or login below.")
-            login() 
-        else:
             logger.warning("Hugging Face user not logged in. Please run `huggingface-cli login` or login below.")
             login() 
         else:

--- a/marsbench/data/__init__.py
+++ b/marsbench/data/__init__.py
@@ -249,7 +249,10 @@ def get_dataset(
             print("Hugging Face user not logged in. Please run `huggingface-cli login` or login below.")
             login() 
         else:
-            print("Hugging Face user is logged in")
+            logger.warning("Hugging Face user not logged in. Please run `huggingface-cli login` or login below.")
+            login() 
+        else:
+            logger.info("Hugging Face user is logged in")
 
         # hf class
         hf_class = HF_REGISTRY[cfg.task]["class"]

--- a/marsbench/data/__init__.py
+++ b/marsbench/data/__init__.py
@@ -13,6 +13,9 @@ from omegaconf import DictConfig
 from torch.utils.data import Dataset
 from torch.utils.data import Subset
 
+from huggingface_hub import HfApi, HfFolder, login, whoami
+from huggingface_hub.utils import HfHubHTTPError
+
 from marsbench.data.segmentation.Mask2FormerWrapper import Mask2FormerWrapper
 
 from .classification import Atmospheric_Dust_Classification_EDR
@@ -24,9 +27,11 @@ from .classification import Frost_Classification
 from .classification import Landmark_Classification
 from .classification import Multi_Label_MER
 from .classification import Surface_Classification
+from .classification import HFClassification
 from .detection import Boulder_Detection
 from .detection import ConeQuest_Detection
 from .detection import Dust_Devil_Detection
+from .detection import HFDetection
 from .segmentation import MMLS
 from .segmentation import Boulder_Segmentation
 from .segmentation import ConeQuest_Segmentation
@@ -35,6 +40,7 @@ from .segmentation import Crater_Multi_Segmentation
 from .segmentation import MarsSegMER
 from .segmentation import MarsSegMSL
 from .segmentation import S5Mars
+from .segmentation import HFSegmentation
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +71,44 @@ DATASET_REGISTRY = {
         "Dust_Devil_Detection": Dust_Devil_Detection,
         "Boulder_Detection": Boulder_Detection,
     },
+}
+
+HF_REGISTRY = {
+    "classification": {
+        "repo_ids": {
+            "DoMars16k": "Mirali33/mb-domars16k",
+            "Landmark_Classification": "Mirali33/mb-landmark_cls",
+            "Surface_Classification": "Mirali33/mb-surface_cls",
+            "Frost_Classification": "Mirali33/mb-frost_cls",
+            "Atmospheric_Dust_Classification_RDR": "Mirali33/mb-atmospheric_dust_cls_rdr",
+            "Atmospheric_Dust_Classification_EDR": "Mirali33/mb-atmospheric_dust_cls_edr",
+            "Change_Classification_HiRISE": "Mirali33/mb-change_cls_hirise",
+            "Change_Classification_CTX": "Mirali33/mb-change_cls_ctx",
+            "Multi_Label_MER": "Mirali33/mb-surface_multi_label_cls",
+        },
+        "class": HFClassification,
+    },
+    "segmentation": {
+        "repo_ids": {
+            "ConeQuest_Segmentation": "Mirali33/mb-conequest_seg",
+            "Boulder_Segmentation": "Mirali33/mb-boulder_seg",
+            "MarsSegMER": "Mirali33/mb-mars_seg_mer",
+            "MarsSegMSL": "Mirali33/mb-mars_seg_msl",
+            "MMLS": "Mirali33/mb-mmls",
+            "S5Mars": "Mirali33/mb-s5mars",
+            "Crater_Binary_Segmentation": "Mirali33/mb-crater_binary_seg",
+            "Crater_Multi_Segmentation": "Mirali33/mb-crater_multi_seg",
+        },
+        "class": HFSegmentation,
+    },
+    "detection": {
+        "repo_ids": {
+            "ConeQuest_Detection": "Mirali33/mb-conequest_det",
+            "Dust_Devil_Detection": "Mirali33/mb-dust_devil_det",
+            "Boulder_Detection": "Mirali33/mb-boulder_det",
+        },
+        "class": HFDetection,
+    }
 }
 
 
@@ -110,6 +154,56 @@ def instantiate_dataset(dataset_class, cfg, transform, split, bbox_format=None, 
     return dataset_class(**common_args)
 
 
+def instantiate_dataset_hf(hf_class, cfg, transform, split, bbox_format=None, annot_csv=None):
+    original_split = split
+    partition_support = ["classification", "segmentation", "detection"]
+    few_shot_support = ["classification"]
+    
+    if (cfg.partition is not None and cfg.task in partition_support) or (
+        cfg.few_shot is not None and cfg.task in few_shot_support
+    ):
+        if cfg.few_shot is not None and cfg.partition is not None:
+            msg = "At most one of cfg.few_shot or cfg.partition may be set; both cannot be non-None"
+            logger.error(msg)
+            raise ValueError(msg)
+        
+        if cfg.few_shot is not None and split == "train":
+            split = f"few_shot_train_{cfg.few_shot}_shot"
+            logger.info(f"Using few-shot split: {split}")
+        elif cfg.partition is not None and split == "train":
+            if cfg.task == "detection":
+                split = f"{cfg.partition:.2f}x_partition"
+            else:
+                split = f"partition_train_{cfg.partition:.2f}x_partition"
+            logger.info(f"Using partition split: {split}")
+    elif cfg.partition is not None:
+        logger.warning(f"Task: {cfg.task} does not support partition. Using whole data.")
+    elif cfg.few_shot is not None:
+        logger.warning(f"Task: {cfg.task} does not support few shot. Using whole data.")
+
+    common_args = {
+        "cfg": cfg,
+        "repo_id": cfg.repo_id,
+        "transform": transform,
+        "split": split,
+    }
+    if cfg.task == "detection":
+        common_args["bbox_format"] = bbox_format
+    return hf_class(**common_args)
+
+
+def is_hf_logged_in():
+    token = HfFolder.get_token()
+    if token is None:
+        return False
+    try:
+        user_info = whoami(token)
+        return True
+    except HfHubHTTPError:
+        return False
+
+
+
 def get_dataset(
     cfg: DictConfig,
     transforms: Tuple[torch.nn.Module, torch.nn.Module],
@@ -133,16 +227,39 @@ def get_dataset(
         Tuple[Dataset, Dataset, Dataset]: Tuple of train, val, and test datasets.
     """
 
-    try:
-        dataset_cls = DATASET_REGISTRY[cfg.task][cfg.data.name]
-    except KeyError as e:
-        logger.error(f"Unsupported dataset {cfg.data.name} for task {cfg.task}")
-        logger.debug(f"Available datasets for task {cfg.task}: {DATASET_REGISTRY[cfg.task]}")
-        raise ValueError(f"Dataset not supported: {cfg.data.name} for {cfg.task}") from e
+    if not cfg.load_from_hf:
+        try:
+            dataset_cls = DATASET_REGISTRY[cfg.task][cfg.data.name]
+        except KeyError as e:
+            logger.error(f"Unsupported dataset {cfg.data.name} for task {cfg.task}")
+            logger.debug(f"Available datasets for task {cfg.task}: {DATASET_REGISTRY[cfg.task]}")
+            raise ValueError(f"Dataset not supported: {cfg.data.name} for {cfg.task}") from e
 
-    train_dataset = instantiate_dataset(dataset_cls, cfg, transforms[0], "train", bbox_format, annot_csv)
-    val_dataset = instantiate_dataset(dataset_cls, cfg, transforms[1], "val", bbox_format, annot_csv)
-    test_dataset = instantiate_dataset(dataset_cls, cfg, transforms[1], "test", bbox_format, annot_csv)
+        train_dataset = instantiate_dataset(dataset_cls, cfg, transforms[0], "train", bbox_format, annot_csv)
+        val_dataset = instantiate_dataset(dataset_cls, cfg, transforms[1], "val", bbox_format, annot_csv)
+        test_dataset = instantiate_dataset(dataset_cls, cfg, transforms[1], "test", bbox_format, annot_csv)
+
+    else:
+        if not cfg.repo_id:
+            logger.warning(f"Using Hugging Face without specifying a repository. Defaulting to {HF_REGISTRY[cfg.task]['repo_ids'][cfg.data.name]}")
+            cfg.repo_id = HF_REGISTRY[cfg.task]["repo_ids"][cfg.data.name]
+            logger.warning(f"Using default repository ID: {cfg.repo_id}")
+        
+        if not is_hf_logged_in():
+            print("Hugging Face user not logged in. Please run `huggingface-cli login` or login below.")
+            login() 
+        else:
+            print("Hugging Face user is logged in")
+
+        # hf class
+        hf_class = HF_REGISTRY[cfg.task]["class"]
+        logger.info(f"Using Hugging Face dataset '{cfg.repo_id}' for task {cfg.task}")
+        train_dataset = instantiate_dataset_hf(hf_class, cfg, transforms[0],
+                                            "train", bbox_format, annot_csv)
+        val_dataset   = instantiate_dataset_hf(hf_class, cfg, transforms[1],
+                                            "val",   bbox_format, annot_csv)
+        test_dataset  = instantiate_dataset_hf(hf_class, cfg, transforms[1],
+                                            "test",  bbox_format, annot_csv)
 
     # Dataset wrapper for Mask2Former
     if cfg.model.name.lower() == "mask2former":

--- a/marsbench/data/classification/BaseClassificationDataset.py
+++ b/marsbench/data/classification/BaseClassificationDataset.py
@@ -63,7 +63,7 @@ class BaseClassificationDataset(Dataset, ABC):
         if self.data_dir:
             logger.info(f"Loading {self.__class__.__name__} from {self.data_dir}")
         else:
-             logger.info(f"Loading {self.__class__.__name__} from HF")
+            logger.info(f"Loading {self.__class__.__name__} from HF")
         self.image_paths, self.gts = self._load_data()
         logger.info(f"Loaded {len(self.image_paths)} images with {len(set(self.gts))} unique classes")
 

--- a/marsbench/data/classification/HFClassification.py
+++ b/marsbench/data/classification/HFClassification.py
@@ -1,0 +1,93 @@
+import logging
+from typing import List, Tuple, Optional, Callable, Literal
+
+
+import numpy as np
+import torch
+from datasets import load_dataset 
+from omegaconf import DictConfig
+from PIL import Image
+import ast
+
+
+from .BaseClassificationDataset import BaseClassificationDataset
+
+
+logger = logging.getLogger(__name__)
+
+
+class HFClassification(BaseClassificationDataset):
+
+    def __init__(
+        self,
+        cfg: DictConfig,
+        repo_id: str,
+        transform,
+        split: Literal["train", "test", "val"]
+    ):
+        self.repo_id = repo_id
+        self.split = split
+        self.hf_cache_dir = cfg.data.get("hf_cache_dir")
+        self.images = []  
+
+        logger.info(f"Initializing HFClassification: repo='{self.repo_id}', split='{self.split}'")
+        if self.hf_cache_dir:
+            logger.info(f"Using Hugging Face cache directory: {self.hf_cache_dir}")
+
+        super().__init__(cfg=cfg, data_dir=None, transform=transform)
+
+    def _load_data(self) -> Tuple[List[str], List[int]]:
+        logger.info(f"Loading Hugging Face dataset '{self.repo_id}' split '{self.split}'...")
+        
+        ds = load_dataset(
+            self.repo_id,
+            split=self.split,
+            cache_dir=self.hf_cache_dir
+        )
+
+        image_column = "image"
+        label_column = "label"
+
+        if image_column not in ds.column_names or label_column not in ds.column_names:
+            raise ValueError(f"Dataset '{self.repo_id}' is missing required columns '{image_column}' or '{label_column}'. Available columns: {ds.column_names}")
+
+        image_paths = []
+        labels = []
+
+        for idx, item in enumerate(ds):
+            image_pil = item[image_column]
+            label = item[label_column]
+
+            if not isinstance(label, int):
+                try:
+                    label = int(label)
+                except ValueError:
+                    logger.error(f"Could not convert label '{label}' to int for item.")
+                    raise 
+
+            self.images.append(image_pil)
+            image_paths.append(f"hf_image_{idx}")  
+            labels.append(label)
+
+        logger.info(f"Successfully extracted {len(image_paths)} images and labels from Hugging Face dataset.")
+        return image_paths, labels
+
+    def __getitem__(self, idx: int) -> Tuple[torch.Tensor, int | torch.Tensor]:
+        
+        image = np.array(self.images[idx].convert(self.image_type))
+        
+        if self.cfg.data.subtask == "multilabel":
+            label = torch.zeros(self.cfg.data.num_classes, dtype=torch.float32)
+            label[ast.literal_eval(str(self.gts[idx]))] = 1
+        elif self.cfg.data.subtask == "binary":
+            label = torch.tensor(self.gts[idx], dtype=torch.float32)
+        else:
+            label = torch.tensor(self.gts[idx], dtype=torch.long)
+
+        if self.transform:
+            transformed = self.transform(image=image)
+            image = transformed["image"]
+        else:
+            image = torch.from_numpy(image)
+
+        return image, label

--- a/marsbench/data/classification/__init__.py
+++ b/marsbench/data/classification/__init__.py
@@ -11,6 +11,7 @@ from .Frost_Classification import Frost_Classification
 from .Landmark_Classification import Landmark_Classification
 from .Multi_Label_MER import Multi_Label_MER
 from .Surface_Classification import Surface_Classification
+from .HFClassification import HFClassification
 
 __all__ = [
     "BaseClassificationDataset",
@@ -23,4 +24,5 @@ __all__ = [
     "Change_Classification_HiRISE",
     "Change_Classification_CTX",
     "Multi_Label_MER",
+    "HFClassification",
 ]

--- a/marsbench/data/detection/HFDetection.py
+++ b/marsbench/data/detection/HFDetection.py
@@ -1,0 +1,167 @@
+"""
+PyTorch Dataset class for loading detection datasets from Hugging Face Hub.
+"""
+
+import logging
+from typing import List, Tuple, Optional, Callable, Literal
+
+import numpy as np
+import torch
+from datasets import load_dataset
+from omegaconf import DictConfig
+from PIL import Image
+
+from .BaseDetectionDataset import BaseDetectionDataset
+
+logger = logging.getLogger(__name__)
+
+
+class HFDetection(BaseDetectionDataset):
+    def __init__(
+        self,
+        cfg: DictConfig,
+        repo_id: str,
+        transform: Optional[Callable] = None,
+        bbox_format: Literal["coco", "yolo", "pascal_voc"] = "yolo",
+        split: Literal["train", "val", "test"] = "train",
+    ):
+        self.repo_id = repo_id
+        self.hf_cache_dir = cfg.data.get("hf_cache_dir")
+        self.images = []  
+
+        logger.info(f"Initializing HFDetection: repo='{self.repo_id}', split='{split}', bbox_format='{bbox_format}'")
+        if self.hf_cache_dir:
+            logger.info(f"Using Hugging Face cache directory: {self.hf_cache_dir}")
+
+        super().__init__(cfg=cfg, data_dir=None, transform=transform, bbox_format=bbox_format, split=split)
+
+    def _load_data(self) -> Tuple[List[str], List[List[float]], List[List[int]], List[str]]:
+        logger.info(f"Loading Hugging Face dataset '{self.repo_id}' split '{self.split}'...")
+        
+        ds = load_dataset(
+            self.repo_id,
+            split=self.split,
+            cache_dir=self.hf_cache_dir
+        )
+
+        image_column = "image"
+        
+        annotation_column_map = {
+            "yolo": "yolo_annotation",
+            "coco": "coco_annotation", 
+            "pascal_voc": "pascal_voc_annotation"
+        }
+        
+        annotation_column = annotation_column_map.get(self.bbox_format)
+        if annotation_column is None:
+            raise ValueError(f"Unsupported bbox_format: {self.bbox_format}. Supported formats: {list(annotation_column_map.keys())}")
+
+        required_columns = [image_column, annotation_column]
+        missing_columns = [col for col in required_columns if col not in ds.column_names]
+        if missing_columns:
+            raise ValueError(f"Dataset '{self.repo_id}' is missing required columns: {missing_columns}. Available: {ds.column_names}")
+
+        image_paths = []
+        annotations = []
+        labels = []
+        image_ids = []
+        
+        
+        class_to_label = {}
+
+        for idx, item in enumerate(ds):
+            image_pil = item[image_column]
+            annotation_data = item[annotation_column]
+
+            # Store PIL image separately
+            self.images.append(image_pil)
+            image_paths.append(f"hf_image_{idx}")  
+            
+            # Parse annotations based on format
+            item_bboxes, item_labels = self._parse_annotations(annotation_data, self.bbox_format, class_to_label)
+            annotations.append(item_bboxes)
+            labels.append(item_labels)
+            image_ids.append(f"hf_id_{idx}")
+
+       
+        self.class_to_label = class_to_label
+        logger.info(f"Class mapping: {class_to_label}")
+        logger.info(f"Successfully extracted {len(image_paths)} images with annotations from Hugging Face dataset.")
+        return image_paths, annotations, labels, image_ids
+
+    def _parse_annotations(self, annotation_data, bbox_format, class_to_label):
+        """Parse annotation data based on the bbox format."""
+        bboxes = []
+        labels = []
+        
+        if not annotation_data:  
+            return bboxes, labels
+            
+        if bbox_format == "yolo":
+            # YOLO format structure: {"bbox": [...], "category": [...]}
+            bbox_list = annotation_data.get("bbox", [])
+            category_list = annotation_data.get("category", [])
+            
+            for bbox, category in zip(bbox_list, category_list):
+                bboxes.append(bbox)  # [x_center, y_center, width, height]
+               
+                if category not in class_to_label:
+                    class_to_label[category] = len(class_to_label) + 1
+                label = class_to_label[category]
+                labels.append(label)
+                    
+        elif bbox_format == "coco":
+            # COCO format structure: {"annotations": {"bbox": [...], "category_id": [...]}}
+            annotations = annotation_data.get("annotations", {})
+            bbox_list = annotations.get("bbox", [])
+            category_ids = annotations.get("category_id", [])
+            
+            for bbox, category_id in zip(bbox_list, category_ids):
+                bboxes.append(bbox)  # [x, y, width, height]
+                labels.append(category_id)  
+                
+        elif bbox_format == "pascal_voc":
+            # Pascal VOC format structure: {"objects": {"bbox": [...], "name": [...]}}
+            objects = annotation_data.get("objects", {})
+            bbox_list = objects.get("bbox", [])
+            names = objects.get("name", [])
+            
+            for bbox_dict, class_name in zip(bbox_list, names):
+                # Convert bbox dict to list [xmin, ymin, xmax, ymax]
+                bbox = [bbox_dict["xmin"], bbox_dict["ymin"], bbox_dict["xmax"], bbox_dict["ymax"]]
+                bboxes.append(bbox)
+                
+                if class_name not in class_to_label:
+                    class_to_label[class_name] = len(class_to_label) + 1
+                label = class_to_label[class_name]
+                labels.append(label)
+                    
+        return bboxes, labels
+    
+    def __getitem__(self, idx) -> Tuple[torch.Tensor, dict]:
+        image = self.images[idx].convert(self.image_type)
+        bboxes = self.annotations[idx]
+        labels = self.labels[idx]
+
+        img_width, img_height = image.size
+        image = np.array(image)
+
+        if self.transform:
+            transformed = self.transform(image=image, bboxes=bboxes, class_labels=labels)
+            image = transformed["image"]
+            img_height, img_width = image.shape[-2:]
+            bboxes = transformed["bboxes"]
+            labels = transformed["class_labels"]
+
+        bboxes = torch.tensor(bboxes, dtype=torch.float32)
+        labels = torch.tensor(labels, dtype=torch.int64)
+
+        target = {
+            "boxes": bboxes,
+            "labels": labels,
+            "image_id": torch.tensor([idx]),
+            "img_size": torch.tensor([img_height, img_width]),
+            "img_scale": torch.tensor([1.0]),
+        }
+
+        return image, target

--- a/marsbench/data/detection/__init__.py
+++ b/marsbench/data/detection/__init__.py
@@ -2,5 +2,6 @@ from .BaseDetectionDataset import BaseDetectionDataset
 from .Boulder_Detection import Boulder_Detection
 from .ConeQuest_Detection import ConeQuest_Detection
 from .Dust_Devil_Detection import Dust_Devil_Detection
+from .HFDetection import HFDetection
 
-__all__ = ["BaseDetectionDataset", "ConeQuest_Detection", "Dust_Devil_Detection", "Boulder_Detection"]
+__all__ = ["BaseDetectionDataset", "ConeQuest_Detection", "Dust_Devil_Detection", "Boulder_Detection", "HFDetection"]

--- a/marsbench/data/segmentation/HFSegmentation.py
+++ b/marsbench/data/segmentation/HFSegmentation.py
@@ -1,0 +1,84 @@
+"""
+PyTorch Dataset class for loading segmentation datasets from Hugging Face Hub.
+"""
+
+import logging
+from typing import List, Tuple, Optional, Callable, Literal
+
+import numpy as np
+import torch
+from datasets import load_dataset
+from omegaconf import DictConfig
+from PIL import Image
+
+from .BaseSegmentationDataset import BaseSegmentationDataset
+
+logger = logging.getLogger(__name__)
+
+
+class HFSegmentation(BaseSegmentationDataset):
+    def __init__(
+        self,
+        cfg: DictConfig,
+        repo_id: str,
+        transform: Optional[Callable] = None,
+        split: Literal["train", "val", "test"] = "train",
+    ):
+        self.repo_id = repo_id
+        self.hf_cache_dir = cfg.data.get("hf_cache_dir")
+        self.images = []  
+        self.masks = []  
+
+        logger.info(f"Initializing HFSegmentation: repo='{self.repo_id}', split='{split}'")
+        if self.hf_cache_dir:
+            logger.info(f"Using Hugging Face cache directory: {self.hf_cache_dir}")
+
+        super().__init__(cfg=cfg, data_dir=None, transform=transform, split=split)
+
+    def _load_data(self) -> Tuple[List[str], List[str]]:
+        logger.info(f"Loading Hugging Face dataset '{self.repo_id}' split '{self.split}'...")
+        
+        ds = load_dataset(
+            self.repo_id,
+            split=self.split,
+            cache_dir=self.hf_cache_dir
+        )
+
+        image_column = "image"
+        mask_column = "mask"
+
+        if image_column not in ds.column_names or mask_column not in ds.column_names:
+            raise ValueError(f"Dataset '{self.repo_id}' is missing required columns '{image_column}' or '{mask_column}'. Available columns: {ds.column_names}")
+
+        image_paths = []
+        mask_paths = []
+
+        for idx, item in enumerate(ds):
+            image_pil = item[image_column]
+            mask_pil = item[mask_column]
+
+            self.images.append(image_pil)
+            self.masks.append(mask_pil)
+            image_paths.append(f"hf_image_{idx}")  
+            mask_paths.append(f"hf_mask_{idx}")   
+
+        logger.info(f"Successfully extracted {len(image_paths)} images and masks from Hugging Face dataset.")
+        return image_paths, mask_paths
+
+    def __getitem__(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor]:
+        image = np.array(self.images[idx].convert(self.image_type))
+        mask = np.array(self.masks[idx].convert("L"))
+
+        if len(mask.shape) == 4:  # One hot encoded mask [N, C, H, W] to class mask [N, H, W]
+            mask = np.argmax(mask, axis=2)
+
+        if self.transform:
+            transformed = self.transform(image=image, mask=mask)
+            image = transformed["image"]
+            mask = transformed["mask"]
+        else:
+            image = torch.from_numpy(image)
+            mask = torch.from_numpy(mask)
+
+        mask = mask.to(torch.int64)
+        return image, mask

--- a/marsbench/data/segmentation/__init__.py
+++ b/marsbench/data/segmentation/__init__.py
@@ -10,6 +10,7 @@ from .MarsSegMER import MarsSegMER
 from .MarsSegMSL import MarsSegMSL
 from .MMLS import MMLS
 from .S5Mars import S5Mars
+from .HFSegmentation import HFSegmentation
 
 __all__ = [
     "BaseSegmentationDataset",
@@ -21,4 +22,6 @@ __all__ = [
     "S5Mars",
     "Crater_Binary_Segmentation",
     "Crater_Multi_Segmentation",
+    "HFSegmentation",
+
 ]


### PR DESCRIPTION
Addition of 2 configurations in config.yaml: load_from_hf flag (true/false) and repo_id (optional string of repository ID from huggingface)

Addition of 3 classes for processing data separately, one for each type of task (classification/segmentation/detection): HFClassification, HFDetection, HFSegmentation

Changes to BaseClassificationDataset.py/ BaseSegmentationDataset.py/ BaseDetectionDataset.py to incorporate loading data from huggingface and bypassing the initializations for the local data directory

Some changes to __init__.py in the data directory in order to treat huggingface approach as per the datasets module of huggingface

Modification of EXAMPLES.md: Added a comprehensive set of explanations and commands to understand how to use MarsBench